### PR TITLE
Fix s3 Test server so that it can handle PUT requests from the AWS CLI correctly

### DIFF
--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -598,7 +598,7 @@ func (objr objectResource) put(a *action) interface{} {
 	objr.bucket.objects[objr.name] = obj
 	
 	h := a.w.Header()
-	h.Set("ETag", fmt.Sprintf("\"%s\"", hex.EncodeToString(obj.checksum)))
+	h.Set("ETag", fmt.Sprintf(`"%s"`, hex.EncodeToString(obj.checksum)))
 	return nil
 }
 

--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	
+	"github.com/goamz/goamz/s3"
 )
 
 const debug = false
@@ -594,6 +596,9 @@ func (objr objectResource) put(a *action) interface{} {
 	obj.checksum = gotHash
 	obj.mtime = time.Now()
 	objr.bucket.objects[objr.name] = obj
+	
+	h := a.w.Header()
+	h.Set("ETag", fmt.Sprintf("\"%s\"", hex.EncodeToString(obj.checksum)))
 	return nil
 }
 


### PR DESCRIPTION
 Set ETag header, enclosed in double-quotes as the AWS CLI expects the ETag header to be set to the MD5 of the uploaded file (within double-quotes)

The double-quotes are necessary as the AWS CLI strips them out before performing an MD5 comparison of the uploaded file.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/siddhuwarrier/goamz/1)

<!-- Reviewable:end -->
